### PR TITLE
Update INSTALL.md to match new Windows Terminal UI

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -8,6 +8,10 @@ Download using the [GitHub `.zip` download](https://github.com/dracula/windows-t
 
 Start Windows Terminal and click on the down arrow symbol `˅` from menu bar. This will open a drop down menu from which select Settings option. Alternatively use `Ctrl + ,` to open Settings directly.
 
+In the bottom left click `Open JSON Settings`
+
+![image](https://github.com/user-attachments/assets/1fef6e24-ea28-4f06-8bb1-06e32294d9f1)
+
 In the `settings.json` settings file for Windows Terminal, find the `schemes` section and paste the content of `dracula.json`.
 
 Example:


### PR DESCRIPTION
Address the old instructions which do not account for the newest Windows Terminal UI changes.

Closes #16 